### PR TITLE
[Feat] RAG 기반 퀴즈 생성 기능 구현 

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -1,0 +1,7 @@
+from sqlalchemy import create_engine
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+DATABASE_URL = os.getenv("DATABASE_URL")
+engine = create_engine(DATABASE_URL)

--- a/app/main.py
+++ b/app/main.py
@@ -1,15 +1,17 @@
 from fastapi import FastAPI
-from app.routers import manual_router
+from app.routers import manual_router, quiz_router, rag_router
 
 # FastAPI 앱 생성
 app = FastAPI(
     title="Altong AI API",
-    version="0.1.0",
-    description="Altong AI 서비스의 메뉴얼 생성용 FastAPI 서버"
+    version="0.2.0",
+    description="RAG 기반 매뉴얼 및 퀴즈 생성 API"
 )
 
 # 라우터 등록
 app.include_router(manual_router.router)
+app.include_router(quiz_router.router)
+app.include_router(rag_router.router)
 
 @app.get("/")
 def root():

--- a/app/models/quiz_model.py
+++ b/app/models/quiz_model.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel
+from typing import List
+
+class QuizItem(BaseModel):
+    type: str
+    question: str
+    options: List[str]
+    answer: str
+    explanation: str
+
+class QuizRequest(BaseModel):
+    manual_id: int
+    tone: str
+
+class QuizResponse(BaseModel):
+    quizzes: List[QuizItem]

--- a/app/routers/quiz_router.py
+++ b/app/routers/quiz_router.py
@@ -1,0 +1,12 @@
+from fastapi import APIRouter, HTTPException
+from app.models.quiz_model import QuizRequest, QuizResponse
+from app.services.quiz_service import generate_quiz
+
+router = APIRouter(prefix="/quiz", tags=["Quiz"])
+
+@router.post("/generate", response_model=QuizResponse)
+def create_quiz(request: QuizRequest):
+    try:
+        return generate_quiz(request.manual_id, request.tone)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/app/routers/rag_router.py
+++ b/app/routers/rag_router.py
@@ -1,0 +1,12 @@
+from fastapi import APIRouter, HTTPException
+from app.services.rag_service import embed_manual
+
+router = APIRouter(prefix="/rag", tags=["RAG"])
+
+@router.post("/embed")
+def create_embeddings(manual_id: int, manual_json: dict):
+    try:
+        embed_manual(manual_id, manual_json)
+        return {"message": f"Manual {manual_id} 임베딩 저장 완료"}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/app/services/quiz_service.py
+++ b/app/services/quiz_service.py
@@ -1,0 +1,67 @@
+from app.core.openai_client import client
+from app.services.rag_service import retrieve_similar
+from app.models.quiz_model import QuizResponse, QuizItem
+import json
+
+def generate_quiz(manual_id: int, tone: str):
+    context_chunks = retrieve_similar(manual_id, "핵심 절차 요약", limit=5)
+    context = "\n".join(context_chunks)
+
+    prompt = f"""
+    너는 소상공인 알바생 교육용 퀴즈를 만드는 전문가야.
+    아래 교육 내용을 바탕으로 3문제를 만들어.
+    
+    - 1번: OX 문제 (보기는 O, X)
+    - 2~3번: 객관식 (보기 2개, A) B) 형식)
+    - 각 문제는 질문(question), 보기(options), 정답(answer), 해설(explanation)을 모두 포함해야 해.
+    - **해설은 반드시 tone에 맞는 사장님의 말투로 작성해.**
+    - tone에 따라 문장 스타일과 어미를 바꿔.
+    - 예시:
+        * formal: "정확히 해야 합니다.", "주의해야 합니다."
+        * friendly: "꼭 확인해줘~", "이 부분은 잊지 말자!"
+        * dialect: "이건 꼭 챙기이소~"
+        * expressive: "좋아요! 완벽해요! 👍"
+    - 반드시 JSON 배열 형식으로만 출력.
+
+    ### tone
+    {tone}
+
+    ### 교육 내용
+    {context}
+
+    ### 출력 예시
+    [
+      {{
+        "type": "OX",
+        "question": "손님이 입장하면 밝게 인사해야 한다.",
+        "options": ["O", "X"],
+        "answer": "O",
+        "explanation": "밝은 인사는 첫인상을 좋게 만들어~ ☀️"
+      }},
+      {{
+        "type": "MULTIPLE",
+        "question": "결제 시 꼭 확인해야 할 것은?",
+        "options": ["A) 금액", "B) 메뉴 수량"],
+        "answer": "A",
+        "explanation": "결제 전에 금액 한 번 더 확인하자~ 💳"
+      }}
+    ]
+    """
+
+    res = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[
+            {"role": "system", "content": "너는 JSON만 반환하는 한국어 퀴즈 생성기야."},
+            {"role": "user", "content": prompt}
+        ],
+        temperature=0.9
+    )
+
+    content = res.choices[0].message.content.strip()
+    content = content.replace("```json", "").replace("```", "")
+    try:
+        data = json.loads(content)
+        quizzes = [QuizItem(**q) for q in data]
+        return QuizResponse(quizzes=quizzes)
+    except Exception as e:
+        raise ValueError(f"퀴즈 파싱 실패: {e}\n응답: {content}")

--- a/app/services/rag_service.py
+++ b/app/services/rag_service.py
@@ -1,0 +1,54 @@
+from app.core.openai_client import client
+from app.core.db import engine
+from sqlalchemy import text
+import re
+
+def chunk_text(manual_json):
+    chunks = []
+    chunks.append(manual_json.get("goal", ""))
+    for p in manual_json.get("procedure", []):
+        if "step" in p:
+            chunks.append(p["step"])
+        if "details" in p:
+            chunks.extend(p["details"])
+    chunks.extend(manual_json.get("precaution", []))
+    return [re.sub(r"\s+", " ", c.strip()) for c in chunks if c.strip()]
+
+def embed_manual(manual_id: int, manual_json: dict):
+    chunks = chunk_text(manual_json)
+    for chunk in chunks:
+        emb = client.embeddings.create(
+            model="text-embedding-3-small",
+            input=chunk
+        ).data[0].embedding
+        with engine.connect() as conn:
+            conn.execute(
+                text("""
+                    INSERT INTO manual_embeddings (manual_id, content, embedding)
+                    VALUES (:manual_id, :content, :embedding)
+                """),
+                {"manual_id": manual_id, "content": chunk, "embedding": emb}
+            )
+            conn.commit()
+
+def retrieve_similar(manual_id: int, query: str, limit: int = 3):
+    q_emb = client.embeddings.create(
+        model="text-embedding-3-small",
+        input=query
+    ).data[0].embedding
+
+    q_emb_str = "[" + ",".join(str(x) for x in q_emb) + "]"  # JSON string 형태로 변환
+
+    with engine.connect() as conn:
+        rows = conn.execute(
+            text("""
+                SELECT content
+                FROM manual_embeddings
+                WHERE manual_id = :manual_id
+                ORDER BY embedding <-> (:q_emb)::vector
+                LIMIT :limit
+            """),
+            {"manual_id": manual_id, "q_emb": q_emb_str, "limit": limit}
+        ).fetchall()
+
+    return [r._mapping["content"] for r in rows]

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,6 @@ tqdm==4.67.1
 typing-inspection==0.4.2
 typing_extensions==4.15.0
 uvicorn==0.38.0
+sqlalchemy==2.0.36
+psycopg2-binary==2.9.9
+numpy==1.26.4


### PR DESCRIPTION
## 📌 관련 이슈
closed #3 


## ✅ 작업 내용
<!-- 작업에 대한 설명을 적어주세요 -->
- 동작 흐름:
  1. 스프링에서 /api/trainings/manual로 메뉴얼 생성 요청 받음. FastAPI에 요청 전달
  2. FastAPI에서 메뉴얼 생성 후 메뉴얼 각 문단(goal, procedure 등)을 chunk로 나눔 -> OpenAI text-embedding-3-small 모델로 임베딩 생성 -> PostgreSQL(RDS)에 벡터 저장
  3. 스프링에서 Training 생성 후 Manual이 저장되며 Quiz 자동 생성 트리거(FastAPI의 /quiz/generate API 호출)
  4. FastAPI에서 퀴즈 생성 (해당 manual_id의 임베딩 벡터를 가져옴 -> "핵심 절차 요약" 문장으로 쿼리 벡터 생성 -> pgvector의 <-> 연산자 로 유사도 높은 chunk 검색 -> 검색된 chunk들을 기반으로 GPT가 OX 문제 1개와 객관식 2개, 해설을 포함한 퀴즈 생성(해설은 tone 반영)
  5. Spring에서 퀴즈 DB 저장 
- 기존 PostgreSQL RDS 를 pgvector 확장하여 각 메뉴얼의 문단별 임베딩 벡터와 해당 문단 내용이 함께 저장하여 의미 기반 검색 RAG를 수행함 